### PR TITLE
Change how templates are imported; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ This module will deploy a Windows virtual machine on Azure with logging and back
 ### Prerequisites
 
 This module requires GET Permission for Keys on management key vault prior to being used.
+
+> If you intend to deploy a Windows Server 2022 the encryption key you reference **has** to be more than 2048 bits, we have tested with 4096 bits, which is confirmed to work.

--- a/datasource.tf
+++ b/datasource.tf
@@ -82,21 +82,3 @@ data "azurerm_storage_account" "logging_storage_account" {
   name                = var.iaas_logging_account_name
   resource_group_name = var.mgmt_resource_group
 }
-
-data "template_file" "iaas_diagnostics_extension_settings" {
-  template = file("${path.module}/iaasDiagnosticsExtensionSettingsTemplate.json.tpl")
-
-  vars = {
-    log_storage_account_name = data.azurerm_storage_account.logging_storage_account.name
-    virtual_machine_id       = azurerm_windows_virtual_machine.virtual_machine.id
-  }
-}
-
-data "template_file" "iaas_diagnostics_extension_protected_settings" {
-  template = file("${path.module}/iaasDiagnosticsExtensionProtectedSettingsTemplate.json.tpl")
-
-  vars = {
-    log_storage_account_name = data.azurerm_storage_account.logging_storage_account.name
-    log_storage_account_key  = data.azurerm_storage_account.logging_storage_account.primary_access_key
-  }
-}

--- a/main.tf
+++ b/main.tf
@@ -159,8 +159,14 @@ resource "azurerm_virtual_machine_extension" "iaas_diagnostics" {
   type                       = "IaaSDiagnostics"
   type_handler_version       = "1.9"
   auto_upgrade_minor_version = true
-  settings                   = data.template_file.iaas_diagnostics_extension_settings.rendered
-  protected_settings         = data.template_file.iaas_diagnostics_extension_protected_settings.rendered
+  settings = templatefile("${path.module}/iaasDiagnosticsExtensionSettingsTemplate.json.tpl", {
+    log_storage_account_name = data.azurerm_storage_account.logging_storage_account.name
+    virtual_machine_id       = azurerm_windows_virtual_machine.virtual_machine.id
+  })
+  protected_settings = templatefile("${path.module}/iaasDiagnosticsExtensionProtectedSettingsTemplate.json.tpl", {
+    log_storage_account_name = data.azurerm_storage_account.logging_storage_account.name
+    log_storage_account_key  = data.azurerm_storage_account.logging_storage_account.primary_access_key
+  })
 }
 
 resource "azurerm_virtual_machine_extension" "domain_Join" {


### PR DESCRIPTION
To allow Apple Silicon users (yours truly) to test and use this module locally, we have stopped using the deprecated `template` provider, in favour of the `templatefile` function. 

Also updated README with findings from @pgskaylink on why Windows Server 2022 couldn't be deployed with disk encryption enabled. (use 4096 bit keys instead of 2048, as per [Microsoft's documentation](https://learn.microsoft.com/en-us/azure/virtual-machines/windows/disk-encryption-overview#supported-operating-systems))